### PR TITLE
added options as parameters

### DIFF
--- a/examples/custom/custom_match_v1.go
+++ b/examples/custom/custom_match_v1.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/fatihkahveci/simple-matchmaking"
+	"time"
+
+	simpe_mm "github.com/fatihkahveci/simple-matchmaking"
 	"github.com/fatihkahveci/simple-matchmaking/server"
 	"github.com/fatihkahveci/simple-matchmaking/store"
-	"time"
 )
 
 type CustomFieldMatchRule struct {
@@ -47,7 +48,15 @@ func main() {
 
 	respServer := server.NewRespServer(inMemory, ":1234")
 
-	matcher := simpe_mm.NewMatchmaking("custom", respServer, inMemory, r, dur)
+	opts := &simpe_mm.Options{
+		Name:    "custom",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    r,
+		Timeout: dur,
+	}
+
+	matcher := simpe_mm.NewMatchmaking(opts)
 
 	matcher.Start()
 }

--- a/examples/score/score.go
+++ b/examples/score/score.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/fatihkahveci/simple-matchmaking"
+	"time"
+
+	simpe_mm "github.com/fatihkahveci/simple-matchmaking"
 	"github.com/fatihkahveci/simple-matchmaking/rules"
 	"github.com/fatihkahveci/simple-matchmaking/server"
 	"github.com/fatihkahveci/simple-matchmaking/store"
-	"time"
 )
 
 func main() {
@@ -16,7 +17,15 @@ func main() {
 
 	respServer := server.NewRespServer(inMemory, ":1234")
 
-	matcher := simpe_mm.NewMatchmaking("score", respServer, inMemory, r, dur)
+	opts := &simpe_mm.Options{
+		Name:    "score",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    r,
+		Timeout: dur,
+	}
+
+	matcher := simpe_mm.NewMatchmaking(opts)
 
 	matcher.Start()
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/fatihkahveci/simple-matchmaking"
+	"time"
+
+	simpe_mm "github.com/fatihkahveci/simple-matchmaking"
 	"github.com/fatihkahveci/simple-matchmaking/rules"
 	"github.com/fatihkahveci/simple-matchmaking/server"
 	"github.com/fatihkahveci/simple-matchmaking/store"
-	"time"
 )
 
 func main() {
@@ -16,7 +17,15 @@ func main() {
 
 	respServer := server.NewRespServer(inMemory, ":1234")
 
-	matcher := simpe_mm.NewMatchmaking("simple", respServer, inMemory, r, dur)
+	opts := &simpe_mm.Options{
+		Name:    "simple",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    r,
+		Timeout: dur,
+	}
+
+	matcher := simpe_mm.NewMatchmaking(opts)
 
 	matcher.Start()
 }

--- a/matchmaking_test.go
+++ b/matchmaking_test.go
@@ -1,13 +1,14 @@
 package simpe_mm_test
 
 import (
-	"github.com/fatihkahveci/simple-matchmaking"
+	"testing"
+	"time"
+
+	simpe_mm "github.com/fatihkahveci/simple-matchmaking"
 	"github.com/fatihkahveci/simple-matchmaking/rules"
 	"github.com/fatihkahveci/simple-matchmaking/server"
 	"github.com/fatihkahveci/simple-matchmaking/store"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestDirectMatchRule(t *testing.T) {
@@ -20,7 +21,15 @@ func TestDirectMatchRule(t *testing.T) {
 		t.Error(err)
 	}
 
-	mm := simpe_mm.NewMatchmaking("test", respServer, inMemory, rule, duration)
+	opts := &simpe_mm.Options{
+		Name:    "test",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    rule,
+		Timeout: duration,
+	}
+
+	mm := simpe_mm.NewMatchmaking(opts)
 
 	u1 := store.User{
 		ID:    "1",
@@ -66,7 +75,15 @@ func TestScoreMatchRule(t *testing.T) {
 		t.Error(err)
 	}
 
-	mm := simpe_mm.NewMatchmaking("test", respServer, inMemory, rule, duration)
+	opts := &simpe_mm.Options{
+		Name:    "test",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    rule,
+		Timeout: duration,
+	}
+
+	mm := simpe_mm.NewMatchmaking(opts)
 
 	u1 := store.User{
 		ID:    "1",
@@ -109,7 +126,15 @@ func TestIsExtendTime(t *testing.T) {
 		t.Error(err)
 	}
 
-	mm := simpe_mm.NewMatchmaking("test", respServer, inMemory, rule, duration)
+	opts := &simpe_mm.Options{
+		Name:    "test",
+		Store:   inMemory,
+		Server:  respServer,
+		Rule:    rule,
+		Timeout: duration,
+	}
+
+	mm := simpe_mm.NewMatchmaking(opts)
 
 	u1 := store.User{
 		ID:    "1",


### PR DESCRIPTION
In matchmaking.go the NewMatchmaking function takes too many parameters. Also these parameters are not simle string or int type parameters. They are domain spesific object which needs to be prepared beforehand.

In such cases, it is preferable to collect the parameters in a single structure as an option. So I created Option struct and give it to NewMatchmaking function.

Also because the package name (simple_mm) is different from the repo name (github.com/fatihkahveci/simple-matchmaking), it is better to add specify the import name like:

`simpe_mm "github.com/fatihkahveci/simple-matchmaking"`